### PR TITLE
Handle purchase order page loading errors

### DIFF
--- a/src/features/lats/components/purchase-order/ProductDetailModal.tsx
+++ b/src/features/lats/components/purchase-order/ProductDetailModal.tsx
@@ -73,6 +73,17 @@ const ProductDetailModal: React.FC<ProductDetailModalProps> = ({
   const [isLoadingStock, setIsLoadingStock] = useState(false);
   const [lastStockUpdate, setLastStockUpdate] = useState<Date | null>(null);
 
+  // Simplified exchange rate calculation (in real app, use live rates)
+  const getExchangeRate = (fromCurrency: string, toCurrency: string): number => {
+    const rates: { [key: string]: { [key: string]: number } } = {
+      'USD': { 'KES': 150, 'EUR': 0.85, 'CNY': 7.2 },
+      'KES': { 'USD': 0.0067, 'EUR': 0.0057, 'CNY': 0.048 },
+      'EUR': { 'USD': 1.18, 'KES': 175, 'CNY': 8.5 },
+      'CNY': { 'USD': 0.14, 'KES': 21, 'EUR': 0.12 }
+    };
+    return rates[fromCurrency]?.[toCurrency] || 1;
+  };
+
   // Initialize with primary variant and supplier data
   useEffect(() => {
     if (product && !selectedVariant) {
@@ -131,16 +142,6 @@ const ProductDetailModal: React.FC<ProductDetailModalProps> = ({
     } finally {
       setIsLoadingStock(false);
     }
-  };
-
-  const getExchangeRate = (fromCurrency: string, toCurrency: string): number => {
-    const rates: { [key: string]: { [key: string]: number } } = {
-      'USD': { 'KES': 150, 'EUR': 0.85, 'CNY': 7.2 },
-      'KES': { 'USD': 0.0067, 'EUR': 0.0057, 'CNY': 0.048 },
-      'EUR': { 'USD': 1.18, 'KES': 175, 'CNY': 8.5 },
-      'CNY': { 'USD': 0.14, 'KES': 21, 'EUR': 0.12 }
-    };
-    return rates[fromCurrency]?.[toCurrency] || 1;
   };
 
   if (!isOpen || !product) return null;


### PR DESCRIPTION
Move `getExchangeRate` function definition to resolve dynamic import errors.

The `getExchangeRate` arrow function was being called within a `useEffect` hook before it was defined in `ProductDetailModal.tsx`. Since arrow functions are not hoisted, this caused a TypeScript compilation error, which led to "Failed to fetch dynamically imported module" errors and a 500 Internal Server Error. Moving the function definition to an earlier point in the file resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2f65119-9cde-4137-9594-21b3879f653e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2f65119-9cde-4137-9594-21b3879f653e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

